### PR TITLE
Make debug tree builder macro function even less work when not debugging.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,11 +24,11 @@ module.exports = class BroccoliConditionalDebug extends Plugin {
     this.debugLabel = label;
     this._sync = undefined;
     this._haveLinked = false;
+    this._shouldSync = shouldSyncDebugDir(label);
   }
 
   build() {
-    let shouldSync = shouldSyncDebugDir(this.debugLabel);
-    if (shouldSync) {
+    if (this._shouldSync) {
       let treeSync = this._sync;
       if (!treeSync) {
         let debugOutputPath = buildDebugOutputPath(this.debugLabel);

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,13 @@ const minimatch = require("minimatch");
 module.exports = class BroccoliConditionalDebug extends Plugin {
   static buildDebugCallback(baseLabel) {
     return (input, label) => {
-      return new this(input, `${baseLabel}:${label}`);
+      let combinedLabel = `${baseLabel}:${label}`;
+
+      if (shouldSyncDebugDir(combinedLabel)) {
+        return new this(input, `${baseLabel}:${label}`);
+      }
+
+      return input;
     };
   }
 

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -39,6 +39,8 @@ describe('BroccoliConditionalDebug', function(hooks) {
 
   describe('BroccoliConditionalDebug.buildDebugCallback', function() {
     it('returns a callback that builds debug trees with a consistent prefix', function(assert) {
+      process.env.BROCCOLI_DEBUG = '*';
+
       let debugTree = BroccoliConditionalDebug.buildDebugCallback('foo-addon');
 
       let tree1 = debugTree(input.path(), 'addon-tree');
@@ -47,6 +49,39 @@ describe('BroccoliConditionalDebug', function(hooks) {
       let tree2 = debugTree(input.path(), 'vendor-tree');
       assert.equal(tree2.debugLabel, 'foo-addon:vendor-tree');
     });
+
+    it('returns the input tree if debug flag does not match label', co.wrap(function* (assert) {
+      input.write(fixture);
+      let inputPath = input.path();
+
+      let debugTree = BroccoliConditionalDebug.buildDebugCallback('foo-bar');
+      let subject = debugTree(inputPath, 'derp');
+
+      assert.equal(subject, inputPath, 'is equal to the input because the label does not match the BROCCOLI_DEBUG flag');
+
+      let output = yield buildOutput(subject);
+
+      assert.deepEqual(output.read(), fixture, 'final output matches input');
+      assert.deepEqual(debug.read(), { }, 'debug tree output is empty');
+    }));
+
+    it('returns a BroccoliConditionalDebug tree when the BROCCOLI_DEBUG flag matches the label', co.wrap(function* (assert) {
+      input.write(fixture);
+      let inputPath = input.path();
+
+      process.env.BROCCOLI_DEBUG = 'foo-bar:herp';
+
+      let debugTree = BroccoliConditionalDebug.buildDebugCallback('foo-bar');
+      let subject = debugTree(inputPath, 'herp');
+
+      assert.notEqual(subject, inputPath, 'tree2 does not match input because the label matches the BROCCOLI_DEBUG flag');
+      assert.ok(subject instanceof BroccoliConditionalDebug, 'tree2 is a BroccoliConditionalDebug instance');
+
+      let output = yield buildOutput(subject);
+
+      assert.deepEqual(output.read(), fixture, 'final ouptut matches input');
+      assert.deepEqual(debug.read(), { 'foo-bar:herp': fixture }, 'debug tree output matches input');
+    }));
   });
 
   it('should pass through', co.wrap(function* (assert) {

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -11,13 +11,22 @@ const describe = QUnit.module;
 const it = QUnit.test;
 
 describe('BroccoliConditionalDebug', function(hooks) {
-  let input, debug;
+  let fixture, input, debug;
 
   hooks.beforeEach(co.wrap(function* () {
     input = yield createTempDir();
     debug = yield createTempDir();
 
     process.env.BROCCOLI_DEBUG_PATH = debug.path();
+
+    fixture = {
+      'foo.txt': 'baas',
+      'derp': {
+        'lol': {
+          'ha!': 'hehe'
+        }
+      }
+    };
   }));
 
   hooks.afterEach(co.wrap(function* () {
@@ -41,15 +50,6 @@ describe('BroccoliConditionalDebug', function(hooks) {
   });
 
   it('should pass through', co.wrap(function* (assert) {
-    let fixture = {
-      'foo.txt': 'baas',
-      'derp': {
-        'lol': {
-          'ha!': 'hehe'
-        }
-      }
-    };
-
     input.write(fixture);
 
     let node = new BroccoliConditionalDebug(input.path(), 'test-1');
@@ -62,14 +62,6 @@ describe('BroccoliConditionalDebug', function(hooks) {
 
   it('should emit a copy of the input into BROCCOLI_DEBUG_PATH', co.wrap(function* (assert) {
     let label = 'test-1';
-    let fixture = {
-      'foo.txt': 'baas',
-      'derp': {
-        'lol': {
-          'ha!': 'hehe'
-        }
-      }
-    };
     input.write(fixture);
 
     process.env.BROCCOLI_DEBUG = '*';
@@ -83,14 +75,6 @@ describe('BroccoliConditionalDebug', function(hooks) {
 
   it('clears stale content from debug path', co.wrap(function* (assert) {
     let label = 'test-1';
-    let fixture = {
-      'foo.txt': 'baas',
-      'derp': {
-        'lol': {
-          'ha!': 'hehe'
-        }
-      }
-    };
     input.write(fixture);
 
     debug.write({


### PR DESCRIPTION
When using an instance of `BroccoliConditionalDebug` we incur a few I/O operations even when not debugging:

* broccoli creates output path
* broccoli-conditional-debug deletes the output path
* broccoli-conditional-debug symlinks the input path to the output path

This change allows the debug tree callback to avoid even that small amount of work. When using `BroccoliConditionalDebug.buildDebugCallback` the only cost is the overhead is the cost of running minimatch to see if we are debugging.